### PR TITLE
Enable training slashes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
-  trailingSlash: false,
+  trailingSlash: true,
   organizationName: 'snowplow',
   projectName: 'snowplow.github.io',
   deploymentBranch: 'main',


### PR DESCRIPTION
The old website favored trailing slashes, and so a lot of links are lying around that have trailing slashes in them.
Unfortunately, the current setup renders a 404 page for a brief moment before redirecting to the correct place.
Enabling trailing slashes in Docusaurus seems to fix the problem, and responds with HTTP 301 for URLs without trailing slashes, which is better for SEO.