### PR TITLE
Add SnowplowDocCard / SnowplowDocCardList components for wrapped text on TOC pages

### DIFF
--- a/docs/collecting-data/collecting-data-from-third-parties/index.md
+++ b/docs/collecting-data/collecting-data-from-third-parties/index.md
@@ -12,7 +12,6 @@ View our [set of trackers for tracking events from your own applications](/docs/
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-data-from-third-parties/index.md
+++ b/docs/collecting-data/collecting-data-from-third-parties/index.md
@@ -11,8 +11,8 @@ Webhooks allow this third-party software to send their own internal event stream
 View our [set of trackers for tracking events from your own applications](/docs/collecting-data/collecting-from-own-applications/index.md).
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/actionscript3-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/actionscript3-tracker/index.md
@@ -15,8 +15,8 @@ The [Snowplow Actionscript 3 (AS3) Tracker](https://github.com/snowplow/snowplo
 The tracker should be straightforward to use if you are comfortable with AS3 development.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/actionscript3-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/actionscript3-tracker/index.md
@@ -16,7 +16,6 @@ The tracker should be straightforward to use if you are comfortable with AS3 dev
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/flutter-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/flutter-tracker/index.md
@@ -16,7 +16,6 @@ The tracker is published on pub.dev as [snowplow\_tracker](https://pub.dev/pack
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/flutter-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/flutter-tracker/index.md
@@ -15,8 +15,8 @@ The Snowplow Flutter Tracker allows you to add analytics to your Flutter apps fo
 The tracker is published on pub.dev as [snowplow\_tracker](https://pub.dev/packages/snowplow_tracker).[](#articles)
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/golang-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/golang-tracker/index.md
@@ -21,8 +21,8 @@ A subject represents a user whose events are tracked. A tracker constructs event
 See [here for instructions](http://blog.ralch.com/tutorial/design-patterns/golang-singleton/) on building a Singleton in Golang.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/golang-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/golang-tracker/index.md
@@ -22,7 +22,6 @@ See [here for instructions](http://blog.ralch.com/tutorial/design-patterns/gola
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/google-amp-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/google-amp-tracker/index.md
@@ -9,8 +9,8 @@ import Badges from '@site/src/components/Badges';
 
 <Badges badgeType="Maintained"></Badges>
 
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/google-amp-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/google-amp-tracker/index.md
@@ -10,7 +10,6 @@ import Badges from '@site/src/components/Badges';
 <Badges badgeType="Maintained"></Badges>
 
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/index.md
@@ -10,7 +10,6 @@ View our [webhooks for tracking events from third-party applications](/docs/coll
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/index.md
@@ -9,8 +9,8 @@ Snowplow Trackers are client- or server-side libraries which enable you to colle
 View our [webhooks for tracking events from third-party applications](/docs/collecting-data/collecting-data-from-third-parties/index.md).
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/java-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/java-tracker/index.md
@@ -15,8 +15,8 @@ The Snowplow Java Tracker lets you add analytics to your [Java](http://www.ja
 The Tracker should be relatively straightforward to setup if you are familiar with Java development.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/java-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/java-tracker/index.md
@@ -16,7 +16,6 @@ The Tracker should be relatively straightforward to setup if you are familiar wi
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md
@@ -13,8 +13,8 @@ import Badges from '@site/src/components/Badges';
 The Browser Tracker is available via `npm` and can be directly bundled into your application. It supports core tracking methods out of the box and can be extended through plugins.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/index.md
@@ -14,7 +14,6 @@ The Browser Tracker is available via `npm` and can be directly bundled into your
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md
@@ -20,7 +20,6 @@ There are currently three trackers:
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/index.md
@@ -19,8 +19,8 @@ There are currently three trackers:
 - **Node.js Tracker (v3)** for use in server-side Node.js environments via npm.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/index.md
@@ -13,8 +13,8 @@ import Badges from '@site/src/components/Badges';
 The JavaScript Tracker supports both synchronous and asynchronous tags. We recommend the asynchronous tags in nearly all instances, as these do not slow down page load times.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/index.md
@@ -14,7 +14,6 @@ The JavaScript Tracker supports both synchronous and asynchronous tags. We recom
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/index.md
@@ -13,8 +13,8 @@ import Block2895 from "@site/docs/reusable/untitled-reusable-block-35/_index.md"
 The JavaScript Tracker supports both synchronous and asynchronous tags. We recommend the asynchronous tags in nearly all instances, as these do not slow down page load times.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/index.md
@@ -14,7 +14,6 @@ The JavaScript Tracker supports both synchronous and asynchronous tags. We recom
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/index.md
@@ -10,7 +10,6 @@ import Block5966 from "@site/docs/reusable/javascript-tracker-release-badge-v3/_
 <Block5966/>
 
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/index.md
@@ -9,8 +9,8 @@ import Block5966 from "@site/docs/reusable/javascript-tracker-release-badge-v3/_
 
 <Block5966/>
 
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md
@@ -16,7 +16,6 @@ The tracker should be straightforward to use if you are comfortable with JavaScr
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/node-js-tracker/index.md
@@ -15,8 +15,8 @@ The Snowplow Node.js Tracker allows you to track Snowplow events from your Nod
 The tracker should be straightforward to use if you are comfortable with JavaScript development; any prior experience with other Snowplow trackers is helpful but not necessary.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/lua-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/lua-tracker/index.md
@@ -69,8 +69,8 @@ tracker:track_struct_event("category", "action", "label", "property", 10)
 Visit documentation about [tracking events](/docs/collecting-data/collecting-from-own-applications/lua-tracker/tracking-specific-events/index.md) to learn about other supported event types.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/lua-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/lua-tracker/index.md
@@ -70,7 +70,6 @@ Visit documentation about [tracking events](/docs/collecting-data/collecting-fr
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md
@@ -12,7 +12,6 @@ import Badges from '@site/src/components/Badges';
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/index.md
@@ -11,8 +11,8 @@ import Badges from '@site/src/components/Badges';
 ```
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/index.md
@@ -5,8 +5,8 @@ sidebar_position: 900
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/index.md
@@ -6,7 +6,6 @@ sidebar_position: 900
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/index.md
@@ -5,8 +5,8 @@ sidebar_position: 900
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/mobile-trackers/previous-versions/index.md
@@ -6,7 +6,6 @@ sidebar_position: 900
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/net-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/net-tracker/index.md
@@ -26,7 +26,6 @@ The Xamarin demo application can be deployed on Android and iOS. Simply launch t
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/net-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/net-tracker/index.md
@@ -25,8 +25,8 @@ This is a Portable Class Library (PCL) wrapper around the core `Snowplow.Tracke
 The Xamarin demo application can be deployed on Android and iOS. Simply launch the `Snowplow.Demo.App.sln` solution file with Visual Studio and deploy to either emulators or actual test devices. The .NET Core Console demo application can also be loaded with Visual Studio using `Snowplow.Demo.Console.sln`.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/index.md
@@ -22,7 +22,6 @@ The current flow of the PHP Tracker is illustrated below:
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/php-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/php-tracker/index.md
@@ -21,8 +21,8 @@ The current flow of the PHP Tracker is illustrated below:
 ![](images/php-tracker-flow.png)
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/python-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/python-tracker/index.md
@@ -19,8 +19,8 @@ There are three basic types of objects you will create when using the Snowplow P
 A subject represents a user whose events are tracked. A tracker constructs events and sends them to one or more emitters. Each emitter then sends the event to the endpoint you configure. This will usually be a Snowplow collector, but could also be a Redis database or Celery task queue.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/collecting-from-own-applications/python-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/python-tracker/index.md
@@ -20,7 +20,6 @@ A subject represents a user whose events are tracked. A tracker constructs event
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/index.md
@@ -12,7 +12,6 @@ import Badges from '@site/src/components/Badges';
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/collecting-data/collecting-from-own-applications/react-native-tracker/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/react-native-tracker/index.md
@@ -11,8 +11,8 @@ import Badges from '@site/src/components/Badges';
 ```
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/index.md
+++ b/docs/collecting-data/index.md
@@ -5,8 +5,8 @@ sidebar_position: 70
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/collecting-data/index.md
+++ b/docs/collecting-data/index.md
@@ -6,7 +6,6 @@ sidebar_position: 70
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/enriching-your-data/available-enrichments/index.md
+++ b/docs/enriching-your-data/available-enrichments/index.md
@@ -10,7 +10,6 @@ import Block1303 from "@site/docs/reusable/untitled-reusable-block-20/_index.md"
 <Block1303/>
 
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/enriching-your-data/available-enrichments/index.md
+++ b/docs/enriching-your-data/available-enrichments/index.md
@@ -9,8 +9,8 @@ import Block1303 from "@site/docs/reusable/untitled-reusable-block-20/_index.md"
 
 <Block1303/>
 
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/enriching-your-data/index.md
+++ b/docs/enriching-your-data/index.md
@@ -6,7 +6,6 @@ sidebar_position: 80
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/enriching-your-data/index.md
+++ b/docs/enriching-your-data/index.md
@@ -5,8 +5,8 @@ sidebar_position: 80
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/forwarding-events-to-destinations/index.md
+++ b/docs/forwarding-events-to-destinations/index.md
@@ -5,8 +5,8 @@ sidebar_position: 100
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/forwarding-events-to-destinations/index.md
+++ b/docs/forwarding-events-to-destinations/index.md
@@ -6,7 +6,6 @@ sidebar_position: 100
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/getting-started-on-snowplow-open-source/index.md
+++ b/docs/getting-started-on-snowplow-open-source/index.md
@@ -6,7 +6,6 @@ sidebar_position: 20
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/getting-started-on-snowplow-open-source/index.md
+++ b/docs/getting-started-on-snowplow-open-source/index.md
@@ -5,8 +5,8 @@ sidebar_position: 20
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/managing-data-quality/failed-events/index.md
+++ b/docs/managing-data-quality/failed-events/index.md
@@ -6,7 +6,6 @@ sidebar_position: 10
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/managing-data-quality/failed-events/index.md
+++ b/docs/managing-data-quality/failed-events/index.md
@@ -5,8 +5,8 @@ sidebar_position: 10
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/managing-data-quality/index.md
+++ b/docs/managing-data-quality/index.md
@@ -5,8 +5,8 @@ sidebar_position: 110
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/managing-data-quality/index.md
+++ b/docs/managing-data-quality/index.md
@@ -6,7 +6,6 @@ sidebar_position: 110
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/modeling-your-data/index.md
+++ b/docs/modeling-your-data/index.md
@@ -5,8 +5,8 @@ sidebar_position: 90
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/modeling-your-data/index.md
+++ b/docs/modeling-your-data/index.md
@@ -6,7 +6,6 @@ sidebar_position: 90
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/open-source-quick-start/index.md
+++ b/docs/open-source-quick-start/index.md
@@ -7,8 +7,8 @@ sidebar_position: 40
 We have built a set of [Terraform](https://registry.terraform.io/namespaces/snowplow-devops) modules, which automates the setting up & deployment of the required infrastructure & applications for an operational Snowplow open source pipeline, with just a handful of input variables required on your side.
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/open-source-quick-start/index.md
+++ b/docs/open-source-quick-start/index.md
@@ -8,7 +8,6 @@ We have built a set of [Terraform](https://registry.terraform.io/namespaces/snow
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/pipeline-components-and-applications/index.md
+++ b/docs/pipeline-components-and-applications/index.md
@@ -6,7 +6,6 @@ sidebar_position: 130
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/pipeline-components-and-applications/index.md
+++ b/docs/pipeline-components-and-applications/index.md
@@ -5,8 +5,8 @@ sidebar_position: 130
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/index.md
@@ -6,7 +6,6 @@ sidebar_position: 60
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/index.md
@@ -5,8 +5,8 @@ sidebar_position: 60
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/previous-versions/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/previous-versions/index.md
@@ -6,7 +6,6 @@ sidebar_position: 30
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/previous-versions/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/snowplow-rdb-loader-3-0-0/previous-versions/index.md
@@ -5,8 +5,8 @@ sidebar_position: 30
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/pipeline-components-and-applications/snowplow-mini/index.md
+++ b/docs/pipeline-components-and-applications/snowplow-mini/index.md
@@ -8,7 +8,6 @@ This is the technical documentation for **Snowplow Mini Version 0.14.x**. For an
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/pipeline-components-and-applications/snowplow-mini/index.md
+++ b/docs/pipeline-components-and-applications/snowplow-mini/index.md
@@ -7,8 +7,8 @@ sidebar_position: 120
 This is the technical documentation for **Snowplow Mini Version 0.14.x**. For an overview of the concepts, read the [Snowplow Mini introduction guide](/docs/understanding-your-pipeline/what-is-snowplow-mini/index.md).
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/try-snowplow/index.md
+++ b/docs/try-snowplow/index.md
@@ -6,7 +6,6 @@ sidebar_position: 30
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/try-snowplow/index.md
+++ b/docs/try-snowplow/index.md
@@ -5,8 +5,8 @@ sidebar_position: 30
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/try-snowplow/recipes/index.md
+++ b/docs/try-snowplow/recipes/index.md
@@ -6,7 +6,6 @@ sidebar_position: 40
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/try-snowplow/recipes/index.md
+++ b/docs/try-snowplow/recipes/index.md
@@ -5,8 +5,8 @@ sidebar_position: 40
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/try-snowplow/setting-up-your-pipeline/index.md
+++ b/docs/try-snowplow/setting-up-your-pipeline/index.md
@@ -6,7 +6,6 @@ sidebar_position: 60
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/try-snowplow/setting-up-your-pipeline/index.md
+++ b/docs/try-snowplow/setting-up-your-pipeline/index.md
@@ -5,8 +5,8 @@ sidebar_position: 60
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/try-snowplow/what-is-try-snowplow/index.md
+++ b/docs/try-snowplow/what-is-try-snowplow/index.md
@@ -2,6 +2,7 @@
 title: "What is Try Snowplow?"
 date: "2020-11-23"
 sidebar_position: 0
+description: "What is Snowplow?"
 ---
 
 Try Snowplow enables you to explore how Snowplow can help you solve your data use cases by:

--- a/docs/try-snowplow/what-is-try-snowplow/index.md
+++ b/docs/try-snowplow/what-is-try-snowplow/index.md
@@ -2,7 +2,6 @@
 title: "What is Try Snowplow?"
 date: "2020-11-23"
 sidebar_position: 0
-description: "What is Snowplow?"
 ---
 
 Try Snowplow enables you to explore how Snowplow can help you solve your data use cases by:

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,7 +2,6 @@
 title: "Tutorials"
 date: "2020-02-24"
 sidebar_position: 150
-description: "A number of tutorials to help you Try Snowplow"
 ---
 
 ```mdx-code-block

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,11 +2,11 @@
 title: "Tutorials"
 date: "2020-02-24"
 sidebar_position: 150
+description: "A number of tutorials to help you Try Snowplow"
 ---
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -5,8 +5,8 @@ sidebar_position: 150
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/understanding-tracking-design/index.md
+++ b/docs/understanding-tracking-design/index.md
@@ -6,7 +6,6 @@ sidebar_position: 60
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/understanding-tracking-design/index.md
+++ b/docs/understanding-tracking-design/index.md
@@ -5,8 +5,8 @@ sidebar_position: 60
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/understanding-your-pipeline/index.md
+++ b/docs/understanding-your-pipeline/index.md
@@ -5,8 +5,8 @@ sidebar_position: 50
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/docs/understanding-your-pipeline/index.md
+++ b/docs/understanding-your-pipeline/index.md
@@ -6,7 +6,6 @@ sidebar_position: 50
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/using-the-snowplow-console/index.md
+++ b/docs/using-the-snowplow-console/index.md
@@ -6,7 +6,6 @@ sidebar_position: 120
 
 ```mdx-code-block
 import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList />
 ```

--- a/docs/using-the-snowplow-console/index.md
+++ b/docs/using-the-snowplow-console/index.md
@@ -5,8 +5,8 @@ sidebar_position: 120
 ---
 
 ```mdx-code-block
-import DocCardList from '@theme/DocCardList';
+import SnowplowDocCardList from '@site/src/components/SnowplowDocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
+<SnowplowDocCardList items={useCurrentSidebarCategory().items}/>
 ```

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.1",
-    "@docusaurus/plugin-client-redirects": "^2.0.1",
-    "@docusaurus/preset-classic": "^2.0.1",
+    "@docusaurus/core": "^2.1.0",
+    "@docusaurus/plugin-client-redirects": "^2.1.0",
+    "@docusaurus/preset-classic": "^2.1.0",
     "@mdx-js/react": "^1.6.22",
     "@snowplow/browser-plugin-link-click-tracking": "^3.5.0",
     "@snowplow/browser-tracker": "^3.5.0",
@@ -30,7 +30,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.1",
+    "@docusaurus/module-type-aliases": "^2.1.0",
     "prettier": "2.7.1"
   },
   "browserslist": {

--- a/src/components/SnowplowDocCard/index.tsx
+++ b/src/components/SnowplowDocCard/index.tsx
@@ -1,0 +1,114 @@
+import React, { type ReactNode } from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {
+    findFirstCategoryLink,
+    useDocById,
+} from '@docusaurus/theme-common/internal';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import { translate } from '@docusaurus/Translate';
+
+import type { Props } from '../SnowplowDocCard';
+import type {
+    PropSidebarItemCategory,
+    PropSidebarItemLink,
+} from '@docusaurus/plugin-content-docs';
+
+import styles from '../SnowplowDocCard/styles.modules.css'
+
+function SnowplowCardContainer({
+    href,
+    children,
+}: {
+    href: string;
+    children: ReactNode;
+}): JSX.Element {
+    return (
+        <Link
+            href={href}
+            className={clsx('card padding--lg', styles.snowplowCardContainer)}>
+            {children}
+        </Link>
+    );
+}
+
+function SnowplowCardLayout({
+    href,
+    icon,
+    title,
+    description,
+}: {
+    href: string;
+    icon: ReactNode;
+    title: string;
+    description?: string;
+}): JSX.Element {
+    return (
+        <SnowplowCardContainer href={href}>
+            <h2 className={clsx('text--wrap', styles.snowplowCardTitle)} title={title}>
+                {icon} {title}
+            </h2>
+            {description && (
+                <p
+                    className={clsx('text--wrap', styles.snowplowCardDescription)}
+                    title={description}>
+                    {description}
+                </p>
+            )}
+        </SnowplowCardContainer>
+    );
+}
+
+function SnowplowCardCategory({
+    item,
+}: {
+    item: PropSidebarItemCategory;
+}): JSX.Element | null {
+    const href = findFirstCategoryLink(item);
+
+    // Unexpected: categories that don't have a link have been filtered upfront
+    if (!href) {
+        return null;
+    }
+
+    return (
+        <SnowplowCardLayout
+            href={href}
+            icon="🗃️"
+            title={item.label}
+            description={translate(
+                {
+                    message: '{count} items',
+                    id: 'theme.docs.SnowplowDocCard.categoryDescription',
+                    description:
+                        'The default description for a category card in the generated index about how many items this category includes',
+                },
+                { count: item.items.length },
+            )}
+        />
+    );
+}
+
+function SnowplowCardLink({ item }: { item: PropSidebarItemLink }): JSX.Element {
+    const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
+    const doc = useDocById(item.docId ?? undefined);
+    return (
+        <SnowplowCardLayout
+            href={item.href}
+            icon={icon}
+            title={item.label}
+            description={doc?.description}
+        />
+    );
+}
+
+export default function SnowplowDocCard({ item }: Props): JSX.Element {
+    switch (item.type) {
+        case 'link':
+            return <SnowplowCardLink item={item} />;
+        case 'category':
+            return <SnowplowCardCategory item={item} />;
+        default:
+            throw new Error(`unknown item type ${JSON.stringify(item)}`);
+    }
+}

--- a/src/components/SnowplowDocCard/index.tsx
+++ b/src/components/SnowplowDocCard/index.tsx
@@ -1,114 +1,123 @@
-import React, { type ReactNode } from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
+import React, { type ReactNode } from 'react'
+import clsx from 'clsx'
+import Link from '@docusaurus/Link'
 import {
-    findFirstCategoryLink,
-    useDocById,
-} from '@docusaurus/theme-common/internal';
-import isInternalUrl from '@docusaurus/isInternalUrl';
-import { translate } from '@docusaurus/Translate';
+  findFirstCategoryLink,
+  useDocById,
+} from '@docusaurus/theme-common/internal'
+import isInternalUrl from '@docusaurus/isInternalUrl'
+import { translate } from '@docusaurus/Translate'
 
-import type { Props } from '../SnowplowDocCard';
+import type { Props } from '../SnowplowDocCard'
 import type {
-    PropSidebarItemCategory,
-    PropSidebarItemLink,
-} from '@docusaurus/plugin-content-docs';
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from '@docusaurus/plugin-content-docs'
 
 import styles from '../SnowplowDocCard/styles.modules.css'
 
 function SnowplowCardContainer({
-    href,
-    children,
+  href,
+  children,
 }: {
-    href: string;
-    children: ReactNode;
+  href: string
+  children: ReactNode
 }): JSX.Element {
-    return (
-        <Link
-            href={href}
-            className={clsx('card padding--lg', styles.snowplowCardContainer)}>
-            {children}
-        </Link>
-    );
+  return (
+    <Link
+      href={href}
+      className={clsx('card padding--lg', styles.snowplowCardContainer)}
+    >
+      {children}
+    </Link>
+  )
 }
 
 function SnowplowCardLayout({
-    href,
-    icon,
-    title,
-    description,
+  href,
+  icon,
+  title,
+  description,
 }: {
-    href: string;
-    icon: ReactNode;
-    title: string;
-    description?: string;
+  href: string
+  icon: ReactNode
+  title: string
+  description?: string
 }): JSX.Element {
-    return (
-        <SnowplowCardContainer href={href}>
-            <h2 className={clsx('text--wrap', styles.snowplowCardTitle)} title={title}>
-                {icon} {title}
-            </h2>
-            {description && (
-                <p
-                    className={clsx('text--wrap', styles.snowplowCardDescription)}
-                    title={description}>
-                    {description}
-                </p>
-            )}
-        </SnowplowCardContainer>
-    );
+  return (
+    <SnowplowCardContainer href={href}>
+      <h2
+        className={clsx('text--wrap', styles.snowplowCardTitle)}
+        title={title}
+      >
+        {icon} {title}
+      </h2>
+      {description && (
+        <p
+          className={clsx('text--wrap', styles.snowplowCardDescription)}
+          title={description}
+        >
+          {description}
+        </p>
+      )}
+    </SnowplowCardContainer>
+  )
 }
 
 function SnowplowCardCategory({
-    item,
+  item,
 }: {
-    item: PropSidebarItemCategory;
+  item: PropSidebarItemCategory
 }): JSX.Element | null {
-    const href = findFirstCategoryLink(item);
+  const href = findFirstCategoryLink(item)
 
-    // Unexpected: categories that don't have a link have been filtered upfront
-    if (!href) {
-        return null;
-    }
+  // Unexpected: categories that don't have a link have been filtered upfront
+  if (!href) {
+    return null
+  }
 
-    return (
-        <SnowplowCardLayout
-            href={href}
-            icon="🗃️"
-            title={item.label}
-            description={translate(
-                {
-                    message: '{count} items',
-                    id: 'theme.docs.SnowplowDocCard.categoryDescription',
-                    description:
-                        'The default description for a category card in the generated index about how many items this category includes',
-                },
-                { count: item.items.length },
-            )}
-        />
-    );
+  return (
+    <SnowplowCardLayout
+      href={href}
+      icon="🗃️"
+      title={item.label}
+      description={translate(
+        {
+          message: '{count} items',
+          id: 'theme.docs.SnowplowDocCard.categoryDescription',
+          description:
+            'The default description for a category card in the generated index about how many items this category includes',
+        },
+        { count: item.items.length }
+      )}
+    />
+  )
 }
 
-function SnowplowCardLink({ item }: { item: PropSidebarItemLink }): JSX.Element {
-    const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
-    const doc = useDocById(item.docId ?? undefined);
-    return (
-        <SnowplowCardLayout
-            href={item.href}
-            icon={icon}
-            title={item.label}
-            description={doc?.description}
-        />
-    );
+function SnowplowCardLink({
+  item,
+}: {
+  item: PropSidebarItemLink
+}): JSX.Element {
+  const icon = isInternalUrl(item.href) ? '📄️' : '🔗'
+  const doc = useDocById(item.docId ?? undefined)
+  return (
+    <SnowplowCardLayout
+      href={item.href}
+      icon={icon}
+      title={item.label}
+      description={doc?.description}
+    />
+  )
 }
 
 export default function SnowplowDocCard({ item }: Props): JSX.Element {
-    switch (item.type) {
-        case 'link':
-            return <SnowplowCardLink item={item} />;
-        case 'category':
-            return <SnowplowCardCategory item={item} />;
-        default:
-            throw new Error(`unknown item type ${JSON.stringify(item)}`);
-    }
+  switch (item.type) {
+    case 'link':
+      return <SnowplowCardLink item={item} />
+    case 'category':
+      return <SnowplowCardCategory item={item} />
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`)
+  }
 }

--- a/src/components/SnowplowDocCard/styles.modules.css
+++ b/src/components/SnowplowDocCard/styles.modules.css
@@ -1,0 +1,27 @@
+ .snowplowCardContainer {
+     --ifm-link-color: var(--ifm-color-emphasis-800);
+     --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+     --ifm-link-hover-decoration: none;
+
+     box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+     border: 1px solid var(--ifm-color-emphasis-200);
+     transition: all var(--ifm-transition-fast) ease;
+     transition-property: border, box-shadow;
+ }
+
+ .snowplowCardContainer:hover {
+     border-color: var(--ifm-color-primary);
+     box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+ }
+
+ .snowplowCardContainer *:last-child {
+     margin-bottom: 0;
+ }
+
+ .snowplowCardTitle {
+     font-size: 1.2rem;
+ }
+
+ .snowplowCardDescription {
+     font-size: 0.8rem;
+ }

--- a/src/components/SnowplowDocCard/styles.modules.css
+++ b/src/components/SnowplowDocCard/styles.modules.css
@@ -1,27 +1,27 @@
- .snowplowCardContainer {
-     --ifm-link-color: var(--ifm-color-emphasis-800);
-     --ifm-link-hover-color: var(--ifm-color-emphasis-700);
-     --ifm-link-hover-decoration: none;
+.snowplowCardContainer {
+  --ifm-link-color: var(--ifm-color-emphasis-800);
+  --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+  --ifm-link-hover-decoration: none;
 
-     box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
-     border: 1px solid var(--ifm-color-emphasis-200);
-     transition: all var(--ifm-transition-fast) ease;
-     transition-property: border, box-shadow;
- }
+  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  transition: all var(--ifm-transition-fast) ease;
+  transition-property: border, box-shadow;
+}
 
- .snowplowCardContainer:hover {
-     border-color: var(--ifm-color-primary);
-     box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
- }
+.snowplowCardContainer:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+}
 
- .snowplowCardContainer *:last-child {
-     margin-bottom: 0;
- }
+.snowplowCardContainer *:last-child {
+  margin-bottom: 0;
+}
 
- .snowplowCardTitle {
-     font-size: 1.2rem;
- }
+.snowplowCardTitle {
+  font-size: 1.2rem;
+}
 
- .snowplowCardDescription {
-     font-size: 0.8rem;
- }
+.snowplowCardDescription {
+  font-size: 0.8rem;
+}

--- a/src/components/SnowplowDocCardList/index.tsx
+++ b/src/components/SnowplowDocCardList/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+    useCurrentSidebarCategory,
+    filterDocCardListItems,
+} from '@docusaurus/theme-common';
+import SnowplowDocCard from '@site/src/components/SnowplowDocCard';
+import type { Props } from '@theme/DocCardList';
+
+function SnowplowDocCardListForCurrentSidebarCategory({ className }: Props) {
+    const category = useCurrentSidebarCategory();
+    return <SnowplowDocCardList items={category.items} className={className} />;
+}
+
+export default function SnowplowDocCardList(props: Props): JSX.Element {
+    const { items, className } = props;
+    if (!items) {
+        return <SnowplowDocCardListForCurrentSidebarCategory {...props} />;
+    }
+    const filteredItems = filterDocCardListItems(items);
+    return (
+        <section className={clsx('row', className)}>
+            {filteredItems.map((item, index) => (
+                <article key={index} className="col col--6 margin-bottom--lg">
+                    <SnowplowDocCard item={item} />
+                </article>
+            ))}
+        </section>
+    );
+}

--- a/src/components/SnowplowDocCardList/index.tsx
+++ b/src/components/SnowplowDocCardList/index.tsx
@@ -1,30 +1,30 @@
-import React from 'react';
-import clsx from 'clsx';
+import React from 'react'
+import clsx from 'clsx'
 import {
-    useCurrentSidebarCategory,
-    filterDocCardListItems,
-} from '@docusaurus/theme-common';
-import SnowplowDocCard from '@site/src/components/SnowplowDocCard';
-import type { Props } from '@theme/DocCardList';
+  useCurrentSidebarCategory,
+  filterDocCardListItems,
+} from '@docusaurus/theme-common'
+import SnowplowDocCard from '@site/src/components/SnowplowDocCard'
+import type { Props } from '@theme/DocCardList'
 
 function SnowplowDocCardListForCurrentSidebarCategory({ className }: Props) {
-    const category = useCurrentSidebarCategory();
-    return <SnowplowDocCardList items={category.items} className={className} />;
+  const category = useCurrentSidebarCategory()
+  return <SnowplowDocCardList items={category.items} className={className} />
 }
 
 export default function SnowplowDocCardList(props: Props): JSX.Element {
-    const { items, className } = props;
-    if (!items) {
-        return <SnowplowDocCardListForCurrentSidebarCategory {...props} />;
-    }
-    const filteredItems = filterDocCardListItems(items);
-    return (
-        <section className={clsx('row', className)}>
-            {filteredItems.map((item, index) => (
-                <article key={index} className="col col--6 margin-bottom--lg">
-                    <SnowplowDocCard item={item} />
-                </article>
-            ))}
-        </section>
-    );
+  const { items, className } = props
+  if (!items) {
+    return <SnowplowDocCardListForCurrentSidebarCategory {...props} />
+  }
+  const filteredItems = filterDocCardListItems(items)
+  return (
+    <section className={clsx('row', className)}>
+      {filteredItems.map((item, index) => (
+        <article key={index} className="col col--6 margin-bottom--lg">
+          <SnowplowDocCard item={item} />
+        </article>
+      ))}
+    </section>
+  )
 }

--- a/src/components/SnowplowDocCardList/index.tsx
+++ b/src/components/SnowplowDocCardList/index.tsx
@@ -5,7 +5,7 @@ import {
   filterDocCardListItems,
 } from '@docusaurus/theme-common'
 import SnowplowDocCard from '@site/src/components/SnowplowDocCard'
-import type { Props } from '@theme/DocCardList'
+import type { Props } from '../SnowplowDocCardList'
 
 function SnowplowDocCardListForCurrentSidebarCategory({ className }: Props) {
   const category = useCurrentSidebarCategory()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,10 +1191,10 @@
     "@docsearch/css" "3.2.1"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.1", "@docusaurus/core@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz"
-  integrity sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==
+"@docusaurus/core@2.1.0", "@docusaurus/core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.1.0.tgz#4aedc306f4c4cd2e0491b641bf78941d4b480ab6"
+  integrity sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==
   dependencies:
     "@babel/core" "^7.18.6"
     "@babel/generator" "^7.18.7"
@@ -1206,13 +1206,13 @@
     "@babel/runtime" "^7.18.6"
     "@babel/runtime-corejs3" "^7.18.6"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/cssnano-preset" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/cssnano-preset" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/mdx-loader" "2.1.0"
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-common" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     "@slorber/static-site-generator-webpack-plugin" "^4.0.7"
     "@svgr/webpack" "^6.2.1"
     autoprefixer "^10.4.7"
@@ -1268,33 +1268,33 @@
     webpack-merge "^5.8.0"
     webpackbar "^5.0.2"
 
-"@docusaurus/cssnano-preset@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz"
-  integrity sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==
+"@docusaurus/cssnano-preset@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz#5b42107769b7cbc61655496090bc262d7788d6ab"
+  integrity sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==
   dependencies:
     cssnano-preset-advanced "^5.3.8"
     postcss "^8.4.14"
     postcss-sort-media-queries "^4.2.1"
     tslib "^2.4.0"
 
-"@docusaurus/logger@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz"
-  integrity sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==
+"@docusaurus/logger@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-2.1.0.tgz#86c97e948f578814d3e61fc2b2ad283043cbe87a"
+  integrity sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.4.0"
 
-"@docusaurus/mdx-loader@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz"
-  integrity sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==
+"@docusaurus/mdx-loader@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz#3fca9576cc73a22f8e7d9941985590b9e47a8526"
+  integrity sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==
   dependencies:
     "@babel/parser" "^7.18.8"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
     "@mdx-js/mdx" "^1.6.22"
     escape-html "^1.0.3"
     file-loader "^6.2.0"
@@ -1309,13 +1309,13 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
-"@docusaurus/module-type-aliases@2.0.1", "@docusaurus/module-type-aliases@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz"
-  integrity sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==
+"@docusaurus/module-type-aliases@2.1.0", "@docusaurus/module-type-aliases@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz#322f8fd5b436af2154c0dddfa173435730e66261"
+  integrity sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==
   dependencies:
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "2.0.1"
+    "@docusaurus/types" "2.1.0"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1323,33 +1323,33 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/plugin-client-redirects@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.1.tgz"
-  integrity sha512-A/giM3MIRRyUmxNzLb/jWvmRf0NtPYX4bV04njAnziAdPo4dqT4dZF2Hvy0uUSaF/SXPGLUjrZWWpzTl5mTJtQ==
+"@docusaurus/plugin-client-redirects@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz#4141040552faad48aefc5bc8f3827c3c4eba1ab8"
+  integrity sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-common" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     eta "^1.12.3"
     fs-extra "^10.1.0"
     lodash "^4.17.21"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-content-blog@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz"
-  integrity sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==
+"@docusaurus/plugin-content-blog@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz#32b1a7cd4b0026f4a76fce4edc5cfdd0edb1ec42"
+  integrity sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/mdx-loader" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-common" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/mdx-loader" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^10.1.0"
@@ -1360,18 +1360,18 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-docs@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz"
-  integrity sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==
+"@docusaurus/plugin-content-docs@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz#3fcdf258c13dde27268ce7108a102b74ca4c279b"
+  integrity sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/mdx-loader" "2.0.1"
-    "@docusaurus/module-type-aliases" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/mdx-loader" "2.1.0"
+    "@docusaurus/module-type-aliases" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     "@types/react-router-config" "^5.0.6"
     combine-promises "^1.1.0"
     fs-extra "^10.1.0"
@@ -1382,84 +1382,84 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-pages@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz"
-  integrity sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==
+"@docusaurus/plugin-content-pages@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz#714d24f71d49dbfed888f50c15e975c2154c3ce8"
+  integrity sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/mdx-loader" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/mdx-loader" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     fs-extra "^10.1.0"
     tslib "^2.4.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-debug@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz"
-  integrity sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==
+"@docusaurus/plugin-debug@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz#b3145affb40e25cf342174638952a5928ddaf7dc"
+  integrity sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
     fs-extra "^10.1.0"
     react-json-view "^1.21.3"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-analytics@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz"
-  integrity sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==
+"@docusaurus/plugin-google-analytics@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz#c9a7269817b38e43484d38fad9996e39aac4196c"
+  integrity sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-gtag@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz"
-  integrity sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==
+"@docusaurus/plugin-google-gtag@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz#e4f351dcd98b933538d55bb742650a2a36ca9a32"
+  integrity sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-sitemap@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz"
-  integrity sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==
+"@docusaurus/plugin-sitemap@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz#b316bb9a42a1717845e26bd4e2d3071748a54b47"
+  integrity sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-common" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     fs-extra "^10.1.0"
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz"
-  integrity sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==
+"@docusaurus/preset-classic@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz#45b23c8ec10c96ded9ece128fac3a39b10bcbc56"
+  integrity sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/plugin-content-blog" "2.0.1"
-    "@docusaurus/plugin-content-docs" "2.0.1"
-    "@docusaurus/plugin-content-pages" "2.0.1"
-    "@docusaurus/plugin-debug" "2.0.1"
-    "@docusaurus/plugin-google-analytics" "2.0.1"
-    "@docusaurus/plugin-google-gtag" "2.0.1"
-    "@docusaurus/plugin-sitemap" "2.0.1"
-    "@docusaurus/theme-classic" "2.0.1"
-    "@docusaurus/theme-common" "2.0.1"
-    "@docusaurus/theme-search-algolia" "2.0.1"
-    "@docusaurus/types" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/plugin-content-blog" "2.1.0"
+    "@docusaurus/plugin-content-docs" "2.1.0"
+    "@docusaurus/plugin-content-pages" "2.1.0"
+    "@docusaurus/plugin-debug" "2.1.0"
+    "@docusaurus/plugin-google-analytics" "2.1.0"
+    "@docusaurus/plugin-google-gtag" "2.1.0"
+    "@docusaurus/plugin-sitemap" "2.1.0"
+    "@docusaurus/theme-classic" "2.1.0"
+    "@docusaurus/theme-common" "2.1.0"
+    "@docusaurus/theme-search-algolia" "2.1.0"
+    "@docusaurus/types" "2.1.0"
 
 "@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
@@ -1469,23 +1469,23 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz"
-  integrity sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==
+"@docusaurus/theme-classic@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz#d957a907ea8dd035c1cf911d0fbe91d8f24aef3f"
+  integrity sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==
   dependencies:
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/mdx-loader" "2.0.1"
-    "@docusaurus/module-type-aliases" "2.0.1"
-    "@docusaurus/plugin-content-blog" "2.0.1"
-    "@docusaurus/plugin-content-docs" "2.0.1"
-    "@docusaurus/plugin-content-pages" "2.0.1"
-    "@docusaurus/theme-common" "2.0.1"
-    "@docusaurus/theme-translations" "2.0.1"
-    "@docusaurus/types" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-common" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/mdx-loader" "2.1.0"
+    "@docusaurus/module-type-aliases" "2.1.0"
+    "@docusaurus/plugin-content-blog" "2.1.0"
+    "@docusaurus/plugin-content-docs" "2.1.0"
+    "@docusaurus/plugin-content-pages" "2.1.0"
+    "@docusaurus/theme-common" "2.1.0"
+    "@docusaurus/theme-translations" "2.1.0"
+    "@docusaurus/types" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-common" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     "@mdx-js/react" "^1.6.22"
     clsx "^1.2.1"
     copy-text-to-clipboard "^3.0.1"
@@ -1500,17 +1500,17 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz"
-  integrity sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==
+"@docusaurus/theme-common@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.1.0.tgz#dff4d5d1e29efc06125dc06f7b259f689bb3f24d"
+  integrity sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==
   dependencies:
-    "@docusaurus/mdx-loader" "2.0.1"
-    "@docusaurus/module-type-aliases" "2.0.1"
-    "@docusaurus/plugin-content-blog" "2.0.1"
-    "@docusaurus/plugin-content-docs" "2.0.1"
-    "@docusaurus/plugin-content-pages" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/mdx-loader" "2.1.0"
+    "@docusaurus/module-type-aliases" "2.1.0"
+    "@docusaurus/plugin-content-blog" "2.1.0"
+    "@docusaurus/plugin-content-docs" "2.1.0"
+    "@docusaurus/plugin-content-pages" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1520,19 +1520,19 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-search-algolia@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz"
-  integrity sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==
+"@docusaurus/theme-search-algolia@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz#e7cdf64b6f7a15b07c6dcf652fd308cfdaabb0ee"
+  integrity sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==
   dependencies:
     "@docsearch/react" "^3.1.1"
-    "@docusaurus/core" "2.0.1"
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/plugin-content-docs" "2.0.1"
-    "@docusaurus/theme-common" "2.0.1"
-    "@docusaurus/theme-translations" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
-    "@docusaurus/utils-validation" "2.0.1"
+    "@docusaurus/core" "2.1.0"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/plugin-content-docs" "2.1.0"
+    "@docusaurus/theme-common" "2.1.0"
+    "@docusaurus/theme-translations" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
+    "@docusaurus/utils-validation" "2.1.0"
     algoliasearch "^4.13.1"
     algoliasearch-helper "^3.10.0"
     clsx "^1.2.1"
@@ -1542,18 +1542,18 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz"
-  integrity sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==
+"@docusaurus/theme-translations@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz#ce9a2955afd49bff364cfdfd4492b226f6dd3b6e"
+  integrity sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==
   dependencies:
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz"
-  integrity sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==
+"@docusaurus/types@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.1.0.tgz#01e13cd9adb268fffe87b49eb90302d5dc3edd6b"
+  integrity sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==
   dependencies:
     "@types/history" "^4.7.11"
     "@types/react" "*"
@@ -1564,30 +1564,30 @@
     webpack "^5.73.0"
     webpack-merge "^5.8.0"
 
-"@docusaurus/utils-common@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz"
-  integrity sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==
+"@docusaurus/utils-common@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.1.0.tgz#248434751096f8c6c644ed65eed2a5a070a227f8"
+  integrity sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==
   dependencies:
     tslib "^2.4.0"
 
-"@docusaurus/utils-validation@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz"
-  integrity sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==
+"@docusaurus/utils-validation@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz#c8cf1d8454d924d9a564fefa86436268f43308e3"
+  integrity sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==
   dependencies:
-    "@docusaurus/logger" "2.0.1"
-    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/logger" "2.1.0"
+    "@docusaurus/utils" "2.1.0"
     joi "^17.6.0"
     js-yaml "^4.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/utils@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz"
-  integrity sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==
+"@docusaurus/utils@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.1.0.tgz#b77b45b22e61eb6c2dcad8a7e96f6db0409b655f"
+  integrity sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==
   dependencies:
-    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/logger" "2.1.0"
     "@svgr/webpack" "^6.2.1"
     file-loader "^6.2.0"
     fs-extra "^10.1.0"


### PR DESCRIPTION
Created two new components (cloned Docusaurus ones and prefixed with Snowplow) to provided wrapped title and description in the TOC pages.

Upgraded to Docusaurus v2.1.0.

Note that definition of description is buried quite deep in Docusaurus so not able to change it without a lot of surgery.  Definition is use description metadata and if not present use the first line of the content.  This is a fundamental of how the sidebars / tocs are based on so that minimal data is being carried around.  We do need to add better descriptions to drive better search/SEO results.  Some first lines are very poor indeed. At least it can all be seen as its wrapped.  Option is to not display the description until we have added better descriptions on TOC pages. 

<img width="1539" alt="image" src="https://user-images.githubusercontent.com/3116331/188175665-3129bc95-749e-44fd-b018-5f2b72ca4d27.png">
