### PR TITLE
Clarify a note about what happens to identifiers when anonymous tracking is enabled in JS tracker

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/additional-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/browser-tracker-v3-reference/tracker-setup/additional-options/index.md
@@ -36,11 +36,19 @@ disableAnonymousTracking({
 });
 ```
 
-**Note:** If configuring the tracker with `stateStorageStrategy: 'localStorage'` and anonymous tracking using `withSessionTracking: true`, then if you change to a `stateStorageStrategy` which prefer cookies such as `cookie` or `cookieAndLocalStorage` then the session identifiers will reset. To maintain session identifiers, ensure you use the same `stateStorageStrategy`.
+:::note
+
+If configuring the tracker with `stateStorageStrategy: 'localStorage'` and anonymous tracking using `withSessionTracking: true`, then if you change to a `stateStorageStrategy` which prefer cookies such as `cookie` or `cookieAndLocalStorage` then the session identifiers will reset. To maintain session identifiers, ensure you use the same `stateStorageStrategy`.
+
+:::
 
 ##### Enable Anonymous Tracking
 
-**Note:** Enabling Anonymous tracking will clear all current user, session and page data.
+:::note
+
+Enabling Anonymous tracking will clear all current user, session and page data from events sent to the collector. Although not sent in requests to collector, existing user and session identifiers will not be removed from cookies or local storage. See below for information on how to clear user data.
+
+:::
 
 If you wish to enable Anonymous Tracking, you can call:
 
@@ -107,7 +115,11 @@ There are many situations, however, when you will want to identify a specific us
 
 Typically, companies do this at points in the customer journey when the user identifies him / herself e.g. if he / she logs in.
 
-Note: this will only set the user ID on further events fired while the user is on this page; if you want events on another page to record this user ID too, you must call `setUserId` on the other page as well.
+:::note
+
+This will only set the user ID on further events fired while the user is on this page; if you want events on another page to record this user ID too, you must call `setUserId` on the other page as well.
+
+:::
 
 ##### `setUserId`
 
@@ -117,7 +129,11 @@ Note: this will only set the user ID on further events fired while the user is o
 setUserId('joe.blogs@email.com');
 ```
 
-Note: `setUserId` can also be called using the alias `identifyUser`.
+:::note
+
+`setUserId` can also be called using the alias `identifyUser`.
+
+:::
 
 ##### `setUserIdFromLocation`
 

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/additional-options/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v3/tracker-setup/additional-options/index.md
@@ -32,11 +32,19 @@ snowplow('disableAnonymousTracking', {
 });
 ```
 
-**Note:** If configuring the tracker with `stateStorageStrategy: 'localStorage'` and anonymous tracking using `withSessionTracking: true`, then if you change to a `stateStorageStrategy` which prefer cookies such as `cookie` or `cookieAndLocalStorage` then the session identifiers will reset. To maintain session identifiers, ensure you use the same `stateStorageStrategy`.
+:::note
+
+If configuring the tracker with `stateStorageStrategy: 'localStorage'` and anonymous tracking using `withSessionTracking: true`, then if you change to a `stateStorageStrategy` which prefer cookies such as `cookie` or `cookieAndLocalStorage` then the session identifiers will reset. To maintain session identifiers, ensure you use the same `stateStorageStrategy`.
+
+:::
 
 ##### Enable Anonymous Tracking
 
-**Note:** Enabling Anonymous tracking will clear all current user, session and page data.
+:::note
+
+Enabling Anonymous tracking will clear all current user, session and page data from events sent to the collector. Although not sent in requests to collector, existing user and session identifiers will not be removed from cookies or local storage. See below for information on how to clear user data.
+
+:::
 
 If you wish to enable Anonymous Tracking, you can call:
 
@@ -92,7 +100,11 @@ There are many situations, however, when you will want to identify a specific us
 
 Typically, companies do this at points in the customer journey when the user identifies him / herself e.g. if he / she logs in.
 
-Note: this will only set the user ID on further events fired while the user is on this page; if you want events on another page to record this user ID too, you must call `setUserId` on the other page as well.
+:::note
+
+This will only set the user ID on further events fired while the user is on this page; if you want events on another page to record this user ID too, you must call `setUserId` on the other page as well.
+
+:::
 
 ##### `setUserId`
 
@@ -102,7 +114,11 @@ Note: this will only set the user ID on further events fired while the user is o
 snowplow('setUserId', 'joe.blogs@email.com');
 ```
 
-Note: `setUserId` can also be called using the alias `identifyUser`.
+:::note
+
+`setUserId` can also be called using the alias `identifyUser`.
+
+:::
 
 ##### `setUserIdFromLocation`
 


### PR DESCRIPTION
This is a small change that expands on the note field in JS tracker docs to give more details on what happens when users call `enableAnonymousTracking`. Also made a few other notes use the `:::note` format.