### PR TITLE
Update javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/javascript-tracker-v2/advanced-usage/getting-the-most-out-of-performance-timing/index.md
@@ -23,3 +23,4 @@ setTimeout(function () {
 ```
 
 This delays its execution until after those NavigationTiming fields are set.
+For further information, see [Measuring page load times with the performance timing context [tutorial] - Discourse](https://discourse.snowplow.io/t/measuring-page-load-times-with-the-performance-timing-context-tutorial/100)


### PR DESCRIPTION
As suggested by @matus-tomlein in [[understood.org] How to track load times #32799](https://snowplow.zendesk.com/agent/tickets/32799)