### PR TITLE
Add pages for configuring cookie flow charts

### DIFF
--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/cookies-and-local-storage/configuring-cookies/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/cookies-and-local-storage/configuring-cookies/index.md
@@ -1,0 +1,11 @@
+---
+title: "Configuring cookie settings"
+date: "2022-09-07"
+sidebar_position: 100
+---
+
+```mdx-code-block
+import Block from "@site/docs/reusable/configuring-cookies/_index.md"
+
+<Block/>
+```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/cookies-and-local-storage/how-the-tracker-stores-state/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/browser-tracker/cookies-and-local-storage/how-the-tracker-stores-state/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How the tracker stores state"
 date: "2021-03-24"
-sidebar_position: 100
+sidebar_position: 200
 ---
 
 ```mdx-code-block

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/cookies-local-storage/configuring-cookies/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/cookies-local-storage/configuring-cookies/index.md
@@ -1,0 +1,11 @@
+---
+title: "Configuring cookie settings"
+date: "2022-09-07"
+sidebar_position: 100
+---
+
+```mdx-code-block
+import Block from "@site/docs/reusable/configuring-cookies/_index.md"
+
+<Block/>
+```

--- a/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/cookies-local-storage/how-the-tracker-stores-state/index.md
+++ b/docs/collecting-data/collecting-from-own-applications/javascript-trackers/javascript-tracker/cookies-local-storage/how-the-tracker-stores-state/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How the tracker stores state"
 date: "2020-03-03"
-sidebar_position: 100
+sidebar_position: 200
 ---
 
 ```mdx-code-block

--- a/docs/reusable/configuring-cookies/_index.md
+++ b/docs/reusable/configuring-cookies/_index.md
@@ -1,4 +1,4 @@
-Snowplow allows for a highly configurable cookie set up. This allows for you to create optimal first party tracking in a privacy-first world, including configurations for anonymous tracking.
+Snowplow allows for a highly configurable cookie set up. This allows for you to create optimal first party tracking in a privacy-first world, including anonymous and cookieless tracking.
 
 Below you'll find a flow chart to help you with your cookie configuration, guiding you through the configuration options for both your [Snowplow Collector](/docs/pipeline-components-and-applications/stream-collector/index.md) and the [Snowplow JavaScript Tracker](/docs//collecting-data/collecting-from-own-applications/javascript-trackers/index.md).
 

--- a/docs/reusable/configuring-cookies/_index.md
+++ b/docs/reusable/configuring-cookies/_index.md
@@ -1,0 +1,6 @@
+Snowplow allows for a highly configurable cookie set up. This allows for you to create optimal first party tracking in a privacy-first world, including configurations for anonymous tracking.
+
+Below you'll find a flow chart to help you with your cookie configuration, guiding you through the configuration options for both your [Snowplow Collector](/docs/pipeline-components-and-applications/stream-collector/index.md) and the [Snowplow JavaScript Tracker](/docs//collecting-data/collecting-from-own-applications/javascript-trackers/index.md).
+
+- [Cookie configuration for open source](/assets/config-calculator-snowplow-open-source.pdf)
+- [Cookie configuration for Snowplow BDP](/assets/config-calculator-snowplow-bdp.pdf)

--- a/docs/reusable/configuring-cookies/_index.md
+++ b/docs/reusable/configuring-cookies/_index.md
@@ -2,5 +2,5 @@ Snowplow allows for a highly configurable cookie set up. This allows for you to 
 
 Below you'll find a flow chart to help you with your cookie configuration, guiding you through the configuration options for both your [Snowplow Collector](/docs/pipeline-components-and-applications/stream-collector/index.md) and the [Snowplow JavaScript Tracker](/docs//collecting-data/collecting-from-own-applications/javascript-trackers/index.md).
 
-- [Cookie configuration for open source](/assets/config-calculator-snowplow-open-source.pdf)
+- [Cookie configuration for Open Source](/assets/config-calculator-snowplow-open-source.pdf)
 - [Cookie configuration for Snowplow BDP](/assets/config-calculator-snowplow-bdp.pdf)


### PR DESCRIPTION
Add pages for configuring cookie flow charts

I know we want to remove the reusable blocks, but we need tabs in place for the JS Tracker. I wanted to get this out now, but will remove the duplication and reusable block once I/we have.