### PR TITLE
Remove enrich setup redirect

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -25,10 +25,6 @@ const redirects = [
     from: '/docs/pipeline-components-and-applications/enrichment-components/enrich-pubsub',
     to: '/docs/pipeline-components-and-applications/enrichment-components/enrich',
   },
-  {
-    from: '/docs/setup-snowplow-on-aws/setup-validation-and-enrich',
-    to: '/docs/getting-started-on-snowplow-open-source/setup-snowplow-on-aws/setup-validation-enrich',
-  },
 ]
 
 module.exports = {


### PR DESCRIPTION
Once https://github.com/snowplow/snowplow/pull/4554 is merged, we can remove this redirect.