### PR TITLE
Remove listen from repeater launch

### DIFF
--- a/docs/pipeline-components-and-applications/loaders-storage-targets/bigquery-loader/index.md
+++ b/docs/pipeline-components-and-applications/loaders-storage-targets/bigquery-loader/index.md
@@ -279,7 +279,6 @@ We recommend constantly running Repeater on a small / cheap node or Docker conta
 $ docker run \
     -v /path/to/configs:/configs \
     snowplow/snowplow-bigquery-repeater:1.4.2 \
-    listen \
     --config=/configs/bigquery.hocon \
     --resolver=/configs/resolver.json \
     --bufferSize=20 \ # size of the batch to send to the dead-letter bucket


### PR DESCRIPTION
When debugging this with an OS user discovered that the guide says to set listen as an input command for the repeater which the repeater does not actually understand.  Removing this line got it working...

Looking in the code I can see listen however as a valid command so I am not sure whats going on here to be honest.

https://github.com/snowplow-incubator/snowplow-bigquery-loader/blob/master/modules/repeater/src/main/scala/com.snowplowanalytics.snowplow.storage.bigquery.repeater/RepeaterCli.scala#L72

Hoping @istreeter can help demystify!

