### PR TITLE
Automatically warn readers about old versions

### DIFF
--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import MDXContent from '@theme-original/MDXContent'
+import Admonition from '@theme-original/Admonition'
+import { useLocation } from '@docusaurus/router'
+
+// yeah, we need to standardize things!
+const previousVersionPattern = new RegExp(
+  '[^/]*(previous-|older-)(versions?|releases?)/.'
+)
+
+export default function MDXContentWrapper(props) {
+  const location = useLocation()
+  return (
+    <>
+      {previousVersionPattern.test(location.pathname) && (
+        <Admonition type="caution">
+          You are reading documentation for an outdated version. Here’s the{' '}
+          <a href={location.pathname.split(previousVersionPattern)[0]}>
+            latest one
+          </a>
+          !
+        </Admonition>
+      )}
+      <MDXContent {...props} />
+    </>
+  )
+}


### PR DESCRIPTION
This appears automatically, as long as the page is within one of the following (yeah, talk about consistency!)
* `.../older-versions/`
* `.../previous-releases/`
* `.../previous-version/`
* `.../previous-versions/`
* `.../rdb-loader-previous-versions/`
* `.../rdb-transformer-previous-versions/`

It *does not* appear on pages listing the content for previous versions — I thought it wouldn’t make much sense, since the title of those pages would already be a dead giveaway.

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/2670454/190488341-a661570a-ef57-47cf-8ffc-ec5c6d78dfa4.png">
